### PR TITLE
Fix Styling for Edit Bani Header

### DIFF
--- a/src/EditBaniOrder/components/Header/index.jsx
+++ b/src/EditBaniOrder/components/Header/index.jsx
@@ -2,9 +2,9 @@ import React, { useCallback } from "react";
 import { View, Text } from "react-native";
 import { Icon } from "@rneui/themed";
 import PropTypes from "prop-types";
-import { STRINGS } from "@common";
 import useTheme from "@common/context";
 import useThemedStyles from "@common/hooks/useThemedStyles";
+import { STRINGS } from "@common";
 import createStyles from "./styles";
 
 const Header = ({ navigation, setReset }) => {

--- a/src/EditBaniOrder/components/Header/styles.js
+++ b/src/EditBaniOrder/components/Header/styles.js
@@ -2,8 +2,8 @@ const createStyles = (theme) => ({
   container: {
     flexDirection: "row",
     justifyContent: "space-between",
-    alignItems: "center",
-    height: theme.components.header.height - theme.spacing.md,
+    alignItems: "flex-end",
+    height: 100,
     padding: theme.spacing.sm,
     backgroundColor: theme.colors.headerVariant,
   },


### PR DESCRIPTION
Bug: Edit Bani order Header was overlapping with status bar. 

Fix Changes.
- Reintroduced the STRINGS import in the Header component for better localization support.
- Updated Header styles to change alignment from "center" to "flex-end" and set a fixed height for consistency across different devices.