### PR TITLE
Minor Pre launch fixes

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -12,6 +12,7 @@ module.exports = {
       "|react-native-gesture-handler" +
       "|react-native-safe-area-context" +
       "|react-native-screens" +
+      "|react-native-fs" +
       ")/)",
   ],
   moduleNameMapper: {

--- a/src/ReaderScreen/components/AudioPlayer/index.jsx
+++ b/src/ReaderScreen/components/AudioPlayer/index.jsx
@@ -3,11 +3,17 @@ import { Linking } from "react-native";
 import TrackPlayer from "react-native-track-player";
 import { useSelector, useDispatch } from "react-redux";
 import PropTypes from "prop-types";
-import { toggleAudio, setDefaultAudio, setAudioProgress } from "@common/actions";
+import {
+  toggleAudio,
+  setDefaultAudio,
+  setAudioProgress,
+  toggleAudioSyncScroll,
+} from "@common/actions";
 import { showErrorToast } from "@common/toast";
 import { STRINGS, logError } from "@common";
 import { AudioTrackDialog, AudioControlBar, ErrorFallback, Loading } from "./components";
 import { useTrackPlayer, useAudioSyncScroll, useAudioManifest } from "./hooks";
+import checkLyricsFileAvailable from "./utils/checkLRC";
 import { getSequenceFromPosition } from "./utils/getSequenceFromPosition";
 
 const AudioPlayer = ({ baniID, title, webViewRef }) => {
@@ -158,6 +164,10 @@ const AudioPlayer = ({ baniID, title, webViewRef }) => {
             selectedTrack.trackSizeMB,
             selectedTrack.remoteUrl || selectedTrack.audioUrl
           );
+        }
+        const isLRCFileAvailable = await checkLyricsFileAvailable(selectedTrack.lyricsUrl);
+        if (isLRCFileAvailable) {
+          dispatch(toggleAudioSyncScroll(true));
         }
       } catch (error) {
         logError("Error switching track:", error);

--- a/src/ReaderScreen/components/AudioPlayer/index.jsx
+++ b/src/ReaderScreen/components/AudioPlayer/index.jsx
@@ -129,6 +129,11 @@ const AudioPlayer = ({ baniID, title, webViewRef }) => {
   const handleTrackSelect = useCallback(
     async (selectedTrack) => {
       try {
+        // Early return if selectedTrack is null or undefined
+        if (!selectedTrack) {
+          return;
+        }
+
         // Stop current playback
         await stop();
 

--- a/src/ReaderScreen/index.jsx
+++ b/src/ReaderScreen/index.jsx
@@ -280,7 +280,7 @@ const Reader = ({ navigation, route }) => {
         {isAutoScroll && <AutoScrollComponent shabadID={id} webViewRef={webViewRef} />}
       </Animated.View>
 
-      <BottomNavigation navigation={navigation} activeKey={isAudio ? "Music" : "Read"} />
+      <BottomNavigation activeKey={isAudio ? "Music" : "Read"} />
     </SafeArea>
   );
 };

--- a/src/ReaderScreen/utils/gutkaScript.js
+++ b/src/ReaderScreen/utils/gutkaScript.js
@@ -207,6 +207,9 @@ ${listener}.addEventListener(
       }
       
       if (element) {
+        // Find the gurmukhi div within the element
+        const gurmukhiDiv = element.querySelector('.gurmukhi') || element;
+        
         // Check if this is the same element as last time
         const isSameElement = lastHighlightedElement === element;
         
@@ -225,7 +228,7 @@ ${listener}.addEventListener(
         // Only scroll if it's a different element
         if (!isSameElement) {
           const behavior = message.behavior === "smooth" ? "smooth" : "auto";
-          element.scrollIntoView({
+          gurmukhiDiv.scrollIntoView({
             behavior: behavior,
             block: "center",
             inline: "nearest"

--- a/src/Settings/index.js
+++ b/src/Settings/index.js
@@ -104,7 +104,7 @@ const Settings = ({ navigation }) => {
         />
         <CustomText style={end} />
       </ScrollView>
-      <BottomNavigation navigation={navigation} activeKey="Settings" />
+      <BottomNavigation activeKey="Settings" />
     </SafeArea>
   );
 };

--- a/src/common/components/BottomNavigation/index.jsx
+++ b/src/common/components/BottomNavigation/index.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useCallback } from "react";
 import { View, Pressable } from "react-native";
 import { useDispatch, useSelector } from "react-redux";
 import { useNavigation } from "@react-navigation/native";
@@ -19,10 +19,10 @@ const BottomNavigation = ({ activeKey }) => {
   const [previousRouteName, setPreviousRouteName] = useState(null);
 
   // Helper function to get current route name
-  const getCurrentRouteName = () => {
+  const getCurrentRouteName = useCallback(() => {
     const navState = navigation.getState();
     return navState?.routes[navState?.index]?.name;
-  };
+  }, [navigation]);
 
   useEffect(() => {
     const updateIsSettings = () => {

--- a/src/common/components/BottomNavigation/index.jsx
+++ b/src/common/components/BottomNavigation/index.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { View, Pressable } from "react-native";
 import { useDispatch, useSelector } from "react-redux";
+import { useNavigation } from "@react-navigation/native";
 import PropTypes from "prop-types";
 import useTheme from "@common/context";
 import useThemedStyles from "@common/hooks/useThemedStyles";
@@ -8,13 +9,20 @@ import { HomeIcon, SettingsIcon, MusicIcon, ReadIcon } from "@common/icons";
 import { CustomText, actions, constant, STRINGS, SafeArea } from "@common";
 import createStyles from "./style";
 
-const BottomNavigation = ({ navigation, activeKey }) => {
+const BottomNavigation = ({ activeKey }) => {
+  const navigation = useNavigation();
   const dispatch = useDispatch();
   const { theme } = useTheme();
   const styles = useThemedStyles(createStyles);
   const isAudio = useSelector((state) => state.isAudio);
-  const currentBani = useSelector((state) => state.currentBani);
   const [isSettings, setIsSettings] = useState(false);
+  const [previousRouteName, setPreviousRouteName] = useState(null);
+
+  // Helper function to get current route name
+  const getCurrentRouteName = () => {
+    const navState = navigation.getState();
+    return navState?.routes[navState?.index]?.name;
+  };
 
   useEffect(() => {
     const updateIsSettings = () => {
@@ -28,6 +36,23 @@ const BottomNavigation = ({ navigation, activeKey }) => {
       if (topRoute?.state && typeof topRoute.state.index === "number") {
         const nestedRoute = topRoute.state.routes[topRoute.state.index];
         currentRouteName = nestedRoute?.name ?? currentRouteName;
+      }
+
+      // When entering Settings, check the previous route in navigation stack
+      if (currentRouteName === constant.SETTINGS) {
+        // Get the previous route from navigation state
+        if (state.index > 0) {
+          const prevRoute = state.routes[state.index - 1];
+          let prevRouteName = prevRoute?.name;
+          if (prevRoute?.state && typeof prevRoute.state.index === "number") {
+            const nestedRoute = prevRoute.state.routes[prevRoute.state.index];
+            prevRouteName = nestedRoute?.name ?? prevRouteName;
+          }
+          setPreviousRouteName(prevRouteName);
+        }
+      } else {
+        // Update previous route when not on Settings
+        setPreviousRouteName(currentRouteName);
       }
 
       setIsSettings(currentRouteName === constant.SETTINGS);
@@ -62,11 +87,14 @@ const BottomNavigation = ({ navigation, activeKey }) => {
       key: "Read",
       icon: ReadIcon,
       handlePress: () => {
-        dispatch(actions.toggleAudio(false));
-        navigation.navigate(constant.READER, {
-          key: `Reader-${currentBani?.id || constant.defaultBani.id}`,
-          params: currentBani || constant.defaultBani,
-        });
+        const currentNavRoute = getCurrentRouteName();
+
+        if (currentNavRoute === constant.SETTINGS) {
+          navigation.goBack();
+        }
+        if (isAudio) {
+          dispatch(actions.toggleAudio(false));
+        }
       },
       text: STRINGS.READ,
     },
@@ -74,18 +102,20 @@ const BottomNavigation = ({ navigation, activeKey }) => {
       key: "Music",
       icon: MusicIcon,
       handlePress: () => {
-        const navState = navigation.getState();
-        const currentNavRoute = navState?.routes[navState?.index]?.name;
-        const isReader = currentNavRoute === constant.READER;
+        const currentNavRoute = getCurrentRouteName();
 
-        if (!isReader) {
-          navigation.navigate(constant.READER, {
-            key: `Reader-${currentBani?.id || constant.defaultBani.id}`,
-            params: currentBani || constant.defaultBani,
-          });
+        if (currentNavRoute === constant.SETTINGS) {
+          navigation.goBack();
         }
+
         dispatch(actions.toggleAutoScroll(false));
-        dispatch(actions.toggleAudio(!isAudio));
+
+        // If coming from Settings and previous route was Reader, keep audio ON
+        if (currentNavRoute === constant.SETTINGS && isAudio) {
+          dispatch(actions.toggleAudio(true));
+        } else {
+          dispatch(actions.toggleAudio(!isAudio));
+        }
       },
       text: STRINGS.MUSIC,
     },
@@ -99,8 +129,9 @@ const BottomNavigation = ({ navigation, activeKey }) => {
     },
   ];
 
-  // Filter out Read and Music when on Settings page
-  const filteredNavigationItems = isSettings
+  // Filter out Read and Music when on Settings page, but keep them if previous route was Read
+  const shouldHideReadAndMusic = isSettings && previousRouteName !== constant.READER;
+  const filteredNavigationItems = shouldHideReadAndMusic
     ? navigationItems.filter((item) => item.key !== "Read" && item.key !== "Music")
     : navigationItems;
 
@@ -138,7 +169,6 @@ const BottomNavigation = ({ navigation, activeKey }) => {
 };
 
 BottomNavigation.propTypes = {
-  navigation: PropTypes.shape().isRequired,
   activeKey: PropTypes.string.isRequired,
 };
 

--- a/src/common/components/BottomNavigation/index.test.jsx
+++ b/src/common/components/BottomNavigation/index.test.jsx
@@ -10,11 +10,21 @@ import BottomNavigation from "./index";
 // Mock styles module used by useThemedStyles (not strictly necessary because we mock the hook)
 jest.mock("./style", () => jest.fn());
 
+// Mock useNavigation hook
+let mockNavigation;
+const mockUseNavigation = jest.fn(() => mockNavigation);
+
+jest.mock("@react-navigation/native", () => ({
+  useNavigation: () => mockUseNavigation(),
+}));
+
 // --- Helpers ---
 
 const createNavigation = ({ currentRoute = "Home" } = {}) => {
   const navigate = jest.fn();
   const popToTop = jest.fn();
+  const goBack = jest.fn();
+  const addListener = jest.fn(() => jest.fn()); // Returns unsubscribe function
   const routes = [{ name: "Home" }, { name: "Reader" }, { name: "Settings" }];
   let index = 0;
   if (currentRoute === "Reader") {
@@ -26,7 +36,7 @@ const createNavigation = ({ currentRoute = "Home" } = {}) => {
     routes,
     index,
   }));
-  return { navigate, getState, popToTop };
+  return { navigate, getState, popToTop, goBack, addListener };
 };
 
 describe("BottomNavigation", () => {
@@ -34,14 +44,13 @@ describe("BottomNavigation", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    setMockState({ isAudio: false, currentBani: { id: 123 } });
+    setMockState({ isAudio: false });
+    mockNavigation = createNavigation();
+    mockUseNavigation.mockReturnValue(mockNavigation);
   });
 
   test("renders four buttons with correct accessibility labels", () => {
-    const navigation = createNavigation();
-    const { getByLabelText } = render(
-      <BottomNavigation navigation={navigation} activeKey="Home" />
-    );
+    const { getByLabelText } = render(<BottomNavigation activeKey="Home" />);
 
     expect(getByLabelText("bottomnav-Home")).toBeTruthy();
     expect(getByLabelText("bottomnav-Read")).toBeTruthy();
@@ -50,8 +59,7 @@ describe("BottomNavigation", () => {
   });
 
   test("shows labels for non-active items and hides label for the active item", () => {
-    const navigation = createNavigation();
-    const { queryByText } = render(<BottomNavigation navigation={navigation} activeKey="Music" />);
+    const { queryByText } = render(<BottomNavigation activeKey="Music" />);
 
     // Active "Music" label should be hidden (component shows label only when NOT active)
     expect(queryByText("Music")).toBeNull();
@@ -63,99 +71,120 @@ describe("BottomNavigation", () => {
   });
 
   test("pressing Home navigates to Home", () => {
-    const navigation = createNavigation();
-    const { getByLabelText } = render(
-      <BottomNavigation navigation={navigation} activeKey="Home" />
-    );
+    const { getByLabelText } = render(<BottomNavigation activeKey="Home" />);
 
     fireEvent.press(getByLabelText("bottomnav-Home"));
 
-    expect(navigation.popToTop).toHaveBeenCalled();
+    expect(mockNavigation.popToTop).toHaveBeenCalled();
   });
 
-  test("pressing Read navigates to Reader with currentBani if present and toggles audio to false", () => {
-    const navigation = createNavigation();
-    const { getByLabelText } = render(
-      <BottomNavigation navigation={navigation} activeKey="Home" />
-    );
+  test("pressing Read when audio is on toggles audio to false", () => {
+    setMockState({ isAudio: true });
+    mockNavigation = createNavigation({ currentRoute: "Home" });
+    mockUseNavigation.mockReturnValue(mockNavigation);
+
+    const { getByLabelText } = render(<BottomNavigation activeKey="Home" />);
 
     fireEvent.press(getByLabelText("bottomnav-Read"));
+
     expect(mockDispatch).toHaveBeenCalledWith({ type: "TOGGLE_AUDIO", payload: false });
-
-    expect(navigation.navigate).toHaveBeenCalledWith("Reader", {
-      key: "Reader-123",
-      params: { id: 123 },
-    });
   });
 
-  test("pressing Read uses defaultBani when currentBani is null", () => {
-    setMockState({ isAudio: false, currentBani: null }); // override for this test
-    const navigation = createNavigation();
-    const { getByLabelText } = render(
-      <BottomNavigation navigation={navigation} activeKey="Home" />
-    );
+  test("pressing Read when audio is off does not toggle audio", () => {
+    setMockState({ isAudio: false });
+    mockNavigation = createNavigation({ currentRoute: "Home" });
+    mockUseNavigation.mockReturnValue(mockNavigation);
+
+    const { getByLabelText } = render(<BottomNavigation activeKey="Home" />);
 
     fireEvent.press(getByLabelText("bottomnav-Read"));
 
-    expect(navigation.navigate).toHaveBeenCalledWith("Reader", {
-      key: "Reader-default",
-      params: { id: "default" },
-    });
+    expect(mockDispatch).not.toHaveBeenCalledWith({ type: "TOGGLE_AUDIO", payload: false });
   });
 
-  test("pressing Music when NOT on Reader navigates to Reader and dispatches actions", () => {
-    const navigation = createNavigation({ currentRoute: "Home" }); // not on Reader
-    const { getByLabelText } = render(
-      <BottomNavigation navigation={navigation} activeKey="Home" />
-    );
+  test("pressing Read from Settings calls goBack", () => {
+    setMockState({ isAudio: false });
+    mockNavigation = createNavigation({ currentRoute: "Settings" });
+    mockUseNavigation.mockReturnValue(mockNavigation);
+
+    const { getByLabelText } = render(<BottomNavigation activeKey="Settings" />);
+
+    fireEvent.press(getByLabelText("bottomnav-Read"));
+
+    expect(mockNavigation.goBack).toHaveBeenCalled();
+  });
+
+  test("pressing Music when NOT on Reader or Settings dispatches actions", () => {
+    setMockState({ isAudio: false });
+    mockNavigation = createNavigation({ currentRoute: "Home" });
+    mockUseNavigation.mockReturnValue(mockNavigation);
+
+    const { getByLabelText } = render(<BottomNavigation activeKey="Home" />);
 
     fireEvent.press(getByLabelText("bottomnav-Music"));
-
-    // Navigates to Reader first
-    expect(navigation.navigate).toHaveBeenCalledWith("Reader", {
-      key: "Reader-123",
-      params: { id: 123 },
-    });
 
     // Dispatches: autoScroll=false, audio toggled from false -> true
     expect(mockDispatch).toHaveBeenCalledWith({ type: "TOGGLE_AUTO_SCROLL", payload: false });
     expect(mockDispatch).toHaveBeenCalledWith({ type: "TOGGLE_AUDIO", payload: true });
   });
 
-  test("pressing Music when ALREADY on Reader does not navigate but still dispatches actions", () => {
-    const navigation = createNavigation({ currentRoute: "Reader" }); // already on Reader
-    const { getByLabelText } = render(
-      <BottomNavigation navigation={navigation} activeKey="Music" />
-    );
+  test("pressing Music when ALREADY on Reader dispatches actions", () => {
+    setMockState({ isAudio: false });
+    mockNavigation = createNavigation({ currentRoute: "Reader" });
+    mockUseNavigation.mockReturnValue(mockNavigation);
+
+    const { getByLabelText } = render(<BottomNavigation activeKey="Music" />);
 
     fireEvent.press(getByLabelText("bottomnav-Music"));
 
-    // No navigation when already on Reader
-    expect(navigation.navigate).not.toHaveBeenCalled();
+    // Dispatches: autoScroll=false, audio toggled from false -> true
+    expect(mockDispatch).toHaveBeenCalledWith({ type: "TOGGLE_AUTO_SCROLL", payload: false });
+    expect(mockDispatch).toHaveBeenCalledWith({ type: "TOGGLE_AUDIO", payload: true });
+  });
 
-    // Still dispatches: autoScroll=false, audio toggled from false -> true
+  test("pressing Music from Settings calls goBack and keeps audio ON if audio was already on", () => {
+    setMockState({ isAudio: true });
+    mockNavigation = createNavigation({ currentRoute: "Settings" });
+    mockUseNavigation.mockReturnValue(mockNavigation);
+
+    const { getByLabelText } = render(<BottomNavigation activeKey="Settings" />);
+
+    fireEvent.press(getByLabelText("bottomnav-Music"));
+
+    expect(mockNavigation.goBack).toHaveBeenCalled();
+    expect(mockDispatch).toHaveBeenCalledWith({ type: "TOGGLE_AUTO_SCROLL", payload: false });
+    expect(mockDispatch).toHaveBeenCalledWith({ type: "TOGGLE_AUDIO", payload: true });
+  });
+
+  test("pressing Music from Settings calls goBack and toggles audio if audio was off", () => {
+    setMockState({ isAudio: false });
+    mockNavigation = createNavigation({ currentRoute: "Settings" });
+    mockUseNavigation.mockReturnValue(mockNavigation);
+
+    const { getByLabelText } = render(<BottomNavigation activeKey="Settings" />);
+
+    fireEvent.press(getByLabelText("bottomnav-Music"));
+
+    expect(mockNavigation.goBack).toHaveBeenCalled();
     expect(mockDispatch).toHaveBeenCalledWith({ type: "TOGGLE_AUTO_SCROLL", payload: false });
     expect(mockDispatch).toHaveBeenCalledWith({ type: "TOGGLE_AUDIO", payload: true });
   });
 
   test("pressing Settings navigates to Settings", () => {
-    const navigation = createNavigation();
-    const { getByLabelText } = render(
-      <BottomNavigation navigation={navigation} activeKey="Home" />
-    );
+    const { getByLabelText } = render(<BottomNavigation activeKey="Home" />);
 
     fireEvent.press(getByLabelText("bottomnav-Settings"));
 
-    expect(navigation.navigate).toHaveBeenCalledWith("Settings");
+    expect(mockNavigation.navigate).toHaveBeenCalledWith("Settings");
   });
 
   test("pressing Music toggles audio based on current isAudio state", () => {
     // Start with isAudio=true to verify toggle -> false
-    setMockState({ isAudio: true, currentBani: { id: 999 } });
-    const navigation = createNavigation({ currentRoute: "Reader" });
-    const { getByLabelText } = render(
-      <BottomNavigation navigation={navigation} activeKey="Music" />
-    );
+    setMockState({ isAudio: true });
+    mockNavigation = createNavigation({ currentRoute: "Reader" });
+    mockUseNavigation.mockReturnValue(mockNavigation);
+
+    const { getByLabelText } = render(<BottomNavigation activeKey="Music" />);
 
     fireEvent.press(getByLabelText("bottomnav-Music"));
 
@@ -166,17 +195,42 @@ describe("BottomNavigation", () => {
   });
 
   test("As a user entering Settings from Home I want irrelevant tabs hidden So that navigation isn't confusing", () => {
-    const navigation = createNavigation({ currentRoute: "Settings" });
-    const { getByLabelText, queryByLabelText } = render(
-      <BottomNavigation navigation={navigation} activeKey="Settings" />
-    );
+    // Simulate coming from Home (not Reader)
+    mockNavigation = createNavigation({ currentRoute: "Settings" });
+    // Set up navigation state to have Home as previous route
+    mockNavigation.getState.mockReturnValue({
+      routes: [{ name: "Home" }, { name: "Settings" }],
+      index: 1,
+    });
+    mockUseNavigation.mockReturnValue(mockNavigation);
+
+    const { getByLabelText, queryByLabelText } = render(<BottomNavigation activeKey="Settings" />);
 
     // Home and Settings should be visible
     expect(getByLabelText("bottomnav-Home")).toBeTruthy();
     expect(getByLabelText("bottomnav-Settings")).toBeTruthy();
 
-    // Read and Music should be hidden on Settings page
+    // Read and Music should be hidden on Settings page when coming from Home
     expect(queryByLabelText("bottomnav-Read")).toBeNull();
     expect(queryByLabelText("bottomnav-Music")).toBeNull();
+  });
+
+  test("As a user entering Settings from Reader I want Read and Music tabs to stay visible", () => {
+    // Simulate coming from Reader
+    mockNavigation = createNavigation({ currentRoute: "Settings" });
+    // Set up navigation state to have Reader as previous route
+    mockNavigation.getState.mockReturnValue({
+      routes: [{ name: "Home" }, { name: "Reader" }, { name: "Settings" }],
+      index: 2,
+    });
+    mockUseNavigation.mockReturnValue(mockNavigation);
+
+    const { getByLabelText } = render(<BottomNavigation activeKey="Settings" />);
+
+    // All tabs should be visible when coming from Reader
+    expect(getByLabelText("bottomnav-Home")).toBeTruthy();
+    expect(getByLabelText("bottomnav-Read")).toBeTruthy();
+    expect(getByLabelText("bottomnav-Music")).toBeTruthy();
+    expect(getByLabelText("bottomnav-Settings")).toBeTruthy();
   });
 });

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -31,3 +31,18 @@ jest.mock("@common", () => {
   const { createCommonMock } = require("@common/test-utils/mocks/common");
   return createCommonMock();
 });
+
+// Mock react-native-fs to avoid TypeScript parsing issues
+jest.mock("react-native-fs", () => ({
+  DocumentDirectoryPath: "/test/documents",
+  exists: jest.fn(() => Promise.resolve(false)),
+  readFile: jest.fn(() => Promise.resolve("")),
+  writeFile: jest.fn(() => Promise.resolve()),
+  unlink: jest.fn(() => Promise.resolve()),
+  mkdir: jest.fn(() => Promise.resolve()),
+  downloadFile: jest.fn(() => Promise.resolve({ statusCode: 200 })),
+  moveFile: jest.fn(() => Promise.resolve()),
+  copyFile: jest.fn(() => Promise.resolve()),
+  readDir: jest.fn(() => Promise.resolve([])),
+  stat: jest.fn(() => Promise.resolve({ isFile: () => true, size: 0 })),
+}));


### PR DESCRIPTION
- enable sync scroll by default where available.
- Highlighted the panktee and scroll to start of the panktee
- fix the bottom navigation to show both reader and audio icons when moving from the Reader to Settings, with 'Settings' highlighted by default.