### PR TITLE
Remove Audio Scroll Settings from SG Settings page. 

### DIFF
--- a/src/Settings/components/audio.jsx
+++ b/src/Settings/components/audio.jsx
@@ -1,12 +1,7 @@
 import React from "react";
 import { useSelector, useDispatch } from "react-redux";
 import { ListItem, Icon, Switch } from "@rneui/themed";
-import {
-  toggleAudio,
-  toggleAudioAutoPlay,
-  toggleAudioSyncScroll,
-  toggleAutoScroll,
-} from "@common/actions";
+import { toggleAudio, toggleAudioAutoPlay, toggleAutoScroll } from "@common/actions";
 import useTheme from "@common/context";
 import useThemedStyles from "@common/hooks/useThemedStyles";
 import { STRINGS, ListItemTitle } from "@common";
@@ -17,10 +12,9 @@ const Audio = () => {
   const styles = useThemedStyles(createStyles);
   const isAudio = useSelector((state) => state.isAudio);
   const isAudioAutoPlay = useSelector((state) => state.isAudioAutoPlay);
-  const isAudioSyncScroll = useSelector((state) => state.isAudioSyncScroll);
   const isAutoScroll = useSelector((state) => state.isAutoScroll);
   const dispatch = useDispatch();
-  const { AUDIO, AUDIO_AUTO_PLAY, AUDIO_SYNC_SCROLL } = STRINGS;
+  const { AUDIO, AUDIO_AUTO_PLAY } = STRINGS;
 
   // Audio settings configuration
   const audioSettings = [
@@ -38,14 +32,6 @@ const Audio = () => {
       icon: "play-circle-outline",
       value: isAudioAutoPlay,
       action: toggleAudioAutoPlay,
-      showAlways: false,
-    },
-    {
-      id: "syncScroll",
-      title: AUDIO_SYNC_SCROLL,
-      icon: "sync",
-      value: isAudioSyncScroll,
-      action: toggleAudioSyncScroll,
       showAlways: false,
     },
   ];


### PR DESCRIPTION
The Audio Scroll Settings have been removed from the SG Settings page for now. We will implement this in future. I have created seperate issue. #362 