### PR TITLE
Updated “Reached End” experience

### DIFF
--- a/src/ReaderScreen/index.jsx
+++ b/src/ReaderScreen/index.jsx
@@ -57,12 +57,11 @@ const Reader = ({ navigation, route }) => {
 
   // Save element ID when leaving screen or app goes to background
   const saveScrollPosition = useCallback(() => {
-    // Prefer element ID if available, otherwise fall back to currentElementId state
     const elementIdToSave = currentElementIdRef.current;
     if (elementIdToSave) {
       dispatch(actions.setPosition(elementIdToSave, id));
     }
-  }, [dispatch, id, currentElementIdRef.current]);
+  }, [dispatch, id]);
 
   useEffect(() => {
     dispatch(actions.setCurrentBani({ id, title, titleUni }));
@@ -158,7 +157,7 @@ const Reader = ({ navigation, route }) => {
       navigation.goBack();
     }
     return true;
-  }, [saveScrollPosition]);
+  }, [saveScrollPosition, navigation]);
 
   useBackHandler(handleBackPress);
 
@@ -208,7 +207,7 @@ const Reader = ({ navigation, route }) => {
       };
       webViewRef.current.postMessage(JSON.stringify(scrollMessage));
     }
-  }, [currentElementIdRef.current]);
+  }, []);
 
   const handleError = useCallback((syntheticEvent) => {
     const { nativeEvent } = syntheticEvent;

--- a/src/ReaderScreen/index.jsx
+++ b/src/ReaderScreen/index.jsx
@@ -44,11 +44,10 @@ const Reader = ({ navigation, route }) => {
   const { title, id, titleUni } = route.params.params || {};
   const [isHeader, toggleHeader] = useState(false);
   const [viewLoaded, toggleViewLoaded] = useState(false);
-  const [currentElementId, setCurrentElementId] = useState(savePosition[id] || null);
   const [shouldNavigateBack, setShouldNavigateBack] = useState(false);
   const [dateKey, setDateKey] = useState(Date.now().toString());
   const [titleText, setTitleText] = useState(null);
-  const currentElementIdRef = useRef(null);
+  const currentElementIdRef = useRef(savePosition[id] || null);
 
   const dispatch = useDispatch();
   const { shabad, isLoading } = useFetchShabad(id);
@@ -59,11 +58,11 @@ const Reader = ({ navigation, route }) => {
   // Save element ID when leaving screen or app goes to background
   const saveScrollPosition = useCallback(() => {
     // Prefer element ID if available, otherwise fall back to currentElementId state
-    const elementIdToSave = currentElementIdRef.current || currentElementId;
+    const elementIdToSave = currentElementIdRef.current;
     if (elementIdToSave) {
       dispatch(actions.setPosition(elementIdToSave, id));
     }
-  }, [dispatch, id, currentElementId]);
+  }, [dispatch, id, currentElementIdRef.current]);
 
   useEffect(() => {
     dispatch(actions.setCurrentBani({ id, title, titleUni }));
@@ -144,11 +143,9 @@ const Reader = ({ navigation, route }) => {
       const savedElementId = savePosition[id];
       // Check if it's a number (old position format) or string (element ID)
       if (typeof savedElementId === "string") {
-        setCurrentElementId(savedElementId);
         currentElementIdRef.current = savedElementId;
       } else if (typeof savedElementId === "number" && savedElementId > 0.9) {
         // Old position format - reset to null if at end
-        setCurrentElementId(null);
         currentElementIdRef.current = null;
       }
     }
@@ -181,7 +178,6 @@ const Reader = ({ navigation, route }) => {
       } else if (data.includes("scroll-elementId-")) {
         // Capture element ID from WebView scroll events
         const elementId = data.split("scroll-elementId-")[1];
-        setCurrentElementId(elementId);
         currentElementIdRef.current = elementId;
         // Save immediately when element ID changes
         dispatch(actions.setPosition(elementId, id));
@@ -189,11 +185,6 @@ const Reader = ({ navigation, route }) => {
           navigation.goBack();
           setShouldNavigateBack(false);
         }
-      } else if (data.includes("reached-end")) {
-        // User reached the end - reset saved position
-        setCurrentElementId(null);
-        currentElementIdRef.current = null;
-        dispatch(actions.setPosition(0, id));
       } else if (data.includes("sequenceString-")) {
         const sequenceStringData = data.split("-")[1];
         dispatch(actions.setBookmarkSequenceString(sequenceStringData));
@@ -210,14 +201,14 @@ const Reader = ({ navigation, route }) => {
 
   const handleLoadEnd = useCallback(() => {
     // Scroll to saved element ID after WebView is fully loaded
-    if (webViewRef.current && currentElementId) {
+    if (webViewRef.current && currentElementIdRef.current) {
       const scrollMessage = {
         action: "scrollToPosition",
-        elementId: currentElementId,
+        elementId: currentElementIdRef.current,
       };
       webViewRef.current.postMessage(JSON.stringify(scrollMessage));
     }
-  }, [currentElementId]);
+  }, [currentElementIdRef.current]);
 
   const handleError = useCallback((syntheticEvent) => {
     const { nativeEvent } = syntheticEvent;

--- a/src/ReaderScreen/utils/gutkaScript.js
+++ b/src/ReaderScreen/utils/gutkaScript.js
@@ -12,6 +12,7 @@ let isScrolling;
 let isManuallyScrolling = false;
 let lastHighlightedElement = null;
 let highlightTimeout = null;
+let hasReachedEnd = false;
 
 const clearScrollTimeout=()=> {
   if (autoScrollTimeout != null) {
@@ -22,12 +23,6 @@ const clearScrollTimeout=()=> {
 
 const scrollFunc=(e)=> {
   const elementId = getTopmostElementId();
-  if (elementId) {
-    window.ReactNativeWebView.postMessage("scroll-elementId-" + elementId);
-  }
-  if (window.scrollY == 0) {
-    window.ReactNativeWebView.postMessage("show");
-  }
 
   // Check if user has reached the end of the document
   const scrollHeight = document.documentElement.scrollHeight;
@@ -36,9 +31,24 @@ const scrollFunc=(e)=> {
   const threshold = 50; // pixels from bottom to consider "at end"
   const isAtEnd = scrollTop + clientHeight >= scrollHeight - threshold;
   
-  if (isAtEnd) {
-    window.ReactNativeWebView.postMessage("reached-end");
+  if (isAtEnd && !hasReachedEnd) {
+    hasReachedEnd = true;
+  } else if (!isAtEnd && hasReachedEnd) {
+    // Reset flag when user scrolls away from the end
+    hasReachedEnd = false;
   }
+  if (elementId && !hasReachedEnd) {
+    window.ReactNativeWebView.postMessage("scroll-elementId-" + elementId);
+  }
+    else if (hasReachedEnd) {
+    window.ReactNativeWebView.postMessage("scroll-elementId-null");
+  }
+
+  
+  if (window.scrollY == 0) {
+    window.ReactNativeWebView.postMessage("show");
+  }
+
 
   if (typeof scrollFunc.y == "undefined") {
     scrollFunc.y = window.pageYOffset;

--- a/src/ReaderScreen/utils/gutkaScript.js
+++ b/src/ReaderScreen/utils/gutkaScript.js
@@ -39,8 +39,7 @@ const scrollFunc=(e)=> {
   }
   if (elementId && !hasReachedEnd) {
     window.ReactNativeWebView.postMessage("scroll-elementId-" + elementId);
-  }
-    else if (hasReachedEnd) {
+  } else if (hasReachedEnd) {
     window.ReactNativeWebView.postMessage("scroll-elementId-null");
   }
 


### PR DESCRIPTION
## Updated “Reached End” experience
When a user reaches the end of a Bani, the next time they open the same Bani it should start from the beginning.
### What changed
- Refactored currentElementId handling to use a ref, improving consistency and avoiding unnecessary re-renders.
- Improved saveScrollPosition to dispatch the correct element ID more reliably.
- Updated WebView message handling to detect “end of document” state and handle it gracefully during scroll.
- Removed redundant currentElementId state updates to simplify logic and streamline the codebase.