### PR TITLE
Add rewind and forward controls to audio player

### DIFF
--- a/src/ReaderScreen/components/AudioPlayer/components/AudioControlBar/index.jsx
+++ b/src/ReaderScreen/components/AudioPlayer/components/AudioControlBar/index.jsx
@@ -18,6 +18,8 @@ import {
   PlayIcon,
   PauseIcon,
   ChevronDownIcon,
+  Replay10Icon,
+  Forward10Icon,
 } from "@common/icons";
 import { STRINGS, CustomText, logError } from "@common";
 import {
@@ -267,13 +269,43 @@ const AudioControlBar = ({
       }
     };
   }, []);
-
+  //
+  const handleSkip = async (seconds) => {
+    try {
+      const currentPosition = progressRef.current?.position || 0;
+      const duration =
+        sliderMax > 0
+          ? sliderMax
+          : progressRef.current?.duration || 0;
+      // Calculate new position
+      let newPosition = currentPosition + seconds;
+      // Keep within bounds
+      if (newPosition < 0) {
+        newPosition = 0;
+      }
+      if (newPosition > duration) {
+        newPosition = duration;
+      }
+      // Update slider immediately
+      setOptimisticSeekPosition(newPosition);
+      if (optimisticSeekTimerRef.current) {
+        clearTimeout(optimisticSeekTimerRef.current);
+      }
+      optimisticSeekTimerRef.current = setTimeout(() => {
+        setOptimisticSeekPosition(null);
+        optimisticSeekTimerRef.current = null;
+      }, 1500);
+      // Seek player
+      await seekTo(newPosition);
+    } catch (error) {
+      logError("Error skipping audio:", error);
+    }
+  };
   const handleSliderSeekComplete = async (valueArray) => {
     const requested = Array.isArray(valueArray) ? Number(valueArray[0]) : Number(valueArray);
     if (!Number.isFinite(requested)) {
       return;
     }
-
     const bounded = sanitizePosition(requested, sliderMax);
     setOptimisticSeekPosition(bounded);
 
@@ -347,22 +379,22 @@ const AudioControlBar = ({
   const actionItems =
     isMoreTracksModalOpen || isSettingsModalOpen
       ? [
-          {
-            onPress: () => {
-              setIsMoreTracksModalOpen(false);
-              setIsSettingsModalOpen(false);
-            },
-            Icon: ChevronDownIcon,
-            id: 1,
+        {
+          onPress: () => {
+            setIsMoreTracksModalOpen(false);
+            setIsSettingsModalOpen(false);
           },
-        ]
+          Icon: ChevronDownIcon,
+          id: 1,
+        },
+      ]
       : [
-          {
-            onPress: handleClose,
-            Icon: CloseIcon,
-            id: 1,
-          },
-        ];
+        {
+          onPress: handleClose,
+          Icon: CloseIcon,
+          id: 1,
+        },
+      ];
 
   useEffect(() => {
     if (isSettingsModalOpen) {
@@ -560,8 +592,13 @@ const AudioControlBar = ({
   return (
     <View style={styles.container} pointerEvents="box-none">
       {isDownloading && !isDownloaded && <DownloadBadge />}
-      {/* Full Player with Animation */}
-      <View style={[styles.mainContainer, Platform.OS === "ios" && styles.mainContainerIOS]}>
+
+      <View
+        style={[
+          styles.mainContainer,
+          Platform.OS === "ios" && styles.mainContainerIOS,
+        ]}
+      >
         {Platform.OS === "ios" && (
           <BlurView
             style={styles.blurOverlay}
@@ -570,6 +607,7 @@ const AudioControlBar = ({
             reducedTransparencyFallbackColor={theme.colors.transparentOverlay}
           />
         )}
+
         {/* Top Control Bar */}
         <View style={styles.topControlBar}>
           <View style={styles.leftControls}>
@@ -586,17 +624,28 @@ const AudioControlBar = ({
 
           <View style={styles.rightControls}>
             {actionItems.map((item) => (
-              <Pressable key={item.id} style={styles.controlIcon} onPress={item.onPress}>
-                <item.Icon size={30} color={theme.colors.audioTitleText} />
+              <Pressable
+                key={item.id}
+                style={styles.controlIcon}
+                onPress={item.onPress}
+              >
+                <item.Icon
+                  size={30}
+                  color={theme.colors.audioTitleText}
+                />
               </Pressable>
             ))}
           </View>
         </View>
-
-        {/* Separator */}
         <View style={styles.separator} />
         <Animated.View
-          style={[styles.modalAnimation, { maxHeight: modalHeight, opacity: modalOpacity }]}
+          style={[
+            styles.modalAnimation,
+            {
+              maxHeight: modalHeight,
+              opacity: modalOpacity,
+            },
+          ]}
         >
           {isSettingsModalOpen && (
             <AudioSettingsModal
@@ -616,70 +665,103 @@ const AudioControlBar = ({
             </View>
           )}
         </Animated.View>
-
         {/* Main Playback Section */}
-        <View style={[styles.mainSection]}>
+        <View style={styles.mainSection}>
           <View style={styles.trackInfo}>
             <View style={styles.trackInfoLeft}>
-              {currentPlaying && currentPlaying.displayName && (
-                <CustomText style={styles.trackName}>{currentPlaying.displayName}</CustomText>
+              {currentPlaying?.displayName && (
+                <CustomText style={styles.trackName}>
+                  {currentPlaying.displayName}
+                </CustomText>
               )}
             </View>
           </View>
-
           <View style={styles.playbackControls}>
-            <Pressable
-              style={styles.playButton}
-              onPress={handlePlayPause}
-              disabled={!isAudioEnabled || isPlayerActionLoading || isBuffering}
-            >
-              {isPlayerActionLoading || isBuffering ? (
-                <ActivityIndicator
-                  testID="player-action-loading-indicator"
-                  size="small"
-                  color={theme.colors.audioTitleText}
-                  style={styles.playButtonLoadingSpinner}
-                />
-              ) : isPlaying ? (
-                <PauseIcon size={30} color={theme.colors.audioTitleText} />
-              ) : (
-                <PlayIcon size={30} color={theme.colors.audioTitleText} />
-              )}
-            </Pressable>
-
             <View style={styles.progressContainer}>
-              <View style={styles.progressBar}>
-                {isSeekLoading && (
-                  <View style={styles.seekLoadingOverlay} testID="seek-loading-indicator">
-                    <ActivityIndicator size="small" color={theme.colors.primary} />
-                  </View>
-                )}
-                <View style={styles.timeRow}>
-                  <CustomText style={[styles.timestamp, styles.timestampWithColor]}>
-                    {formatTime(safePosition)}
-                  </CustomText>
-                  <CustomText style={[styles.timestamp, styles.timestampWithColor]}>
-                    {sliderMax > 0 ? formatTime(sliderMax) : "0:00"}
-                  </CustomText>
+              <View style={styles.timeRow}>
+                {/* Current Time */}
+                <CustomText
+                  style={[styles.timestamp, styles.timestampWithColor]}
+                >
+                  {formatTime(safePosition)}
+                </CustomText>
+                {/* Center Controls */}
+                <View style={styles.centerPlaybackControls}>
+                  {/* Replay 10 */}
+                  <Pressable
+                    style={styles.skipButton}
+                    onPress={() => handleSkip(-10)}
+                    disabled={!isAudioEnabled || isSeekLoading}
+                  >
+                    <Replay10Icon
+                      size={25}
+                      color={theme.colors.audioTitleText}
+                    />
+                  </Pressable>
+                  {/* Play Pause */}
+                  <Pressable
+                    style={styles.playButton}
+                    onPress={handlePlayPause}
+                    disabled={
+                      !isAudioEnabled ||
+                      isPlayerActionLoading ||
+                      isBuffering
+                    }
+                  >
+                    {isPlayerActionLoading || isBuffering ? (
+                      <ActivityIndicator
+                        size="small"
+                        color={theme.colors.audioTitleText}
+                      />
+                    ) : isPlaying ? (
+                      <PauseIcon
+                        size={40}
+                        color={theme.colors.audioTitleText}
+                      />
+                    ) : (
+                      <PlayIcon
+                        size={40}
+                        color={theme.colors.audioTitleText}
+                      />
+                    )}
+                  </Pressable>
+                  {/* Forward 10 */}
+                  <Pressable
+                    style={styles.skipButton}
+                    onPress={() => handleSkip(10)}
+                    disabled={!isAudioEnabled || isSeekLoading}
+                  >
+                    <Forward10Icon
+                      size={25}
+                      color={theme.colors.audioTitleText}
+                    />
+                  </Pressable>
                 </View>
-                <Slider
-                  value={safePosition}
-                  minimumValue={0}
-                  maximumValue={sliderMax}
-                  onSlidingComplete={handleSliderSeekComplete}
-                  minimumTrackTintColor={sliderMinTrackColor}
-                  maximumTrackTintColor={theme.staticColors.SLIDER_TRACK_COLOR}
-                  disabled={!isAudioEnabled || isSeekLoading}
-                  trackStyle={{
-                    height: 6,
-                    borderRadius: 3,
-                  }}
-                  thumbStyle={{
-                    width: 10,
-                    height: 10,
-                  }}
-                />
+                {/* Total Time */}
+                <CustomText
+                  style={[styles.timestamp, styles.timestampWithColor]}
+                >
+                  {sliderMax > 0 ? formatTime(sliderMax) : "0:00"}
+                </CustomText>
               </View>
+              {/* Progress Slider */}
+              <Slider
+                value={safePosition}
+                minimumValue={0}
+                maximumValue={sliderMax}
+                onSlidingComplete={handleSliderSeekComplete}
+                minimumTrackTintColor={sliderMinTrackColor}
+                maximumTrackTintColor={theme.staticColors.SLIDER_TRACK_COLOR}
+                disabled={!isAudioEnabled || isSeekLoading}
+                trackStyle={{
+                  height: 6,
+                  borderRadius: 3,
+                }}
+                thumbStyle={{
+                  width: 10,
+                  height: 10,
+                }}
+              />
             </View>
           </View>
         </View>

--- a/src/ReaderScreen/components/AudioPlayer/style.js
+++ b/src/ReaderScreen/components/AudioPlayer/style.js
@@ -93,8 +93,6 @@ export const audioControlBarStyles = (theme) => ({
     height: 40,
     padding: 5,
     width: "100%",
-    marginLeft: "auto",
-    marginRight: "auto",
     zIndex: 1,
   },
   leftControls: {
@@ -155,33 +153,46 @@ export const audioControlBarStyles = (theme) => ({
     fontFamily: theme.typography.fonts.balooPaaji,
     marginBottom: 2,
   },
-  playbackControls: {
-    flexDirection: "row",
-    paddingHorizontal: theme.spacing.md_12,
-    gap: theme.spacing.md_12,
-  },
-  playButton: {
-    justifyContent: "center",
-    alignItems: "center",
-  },
-  playButtonLoadingSpinner: {
-    minWidth: 30,
-  },
-  progressContainer: {
-    flex: 1,
-    marginTop: 2,
-    justifyContent: "center",
-  },
+playbackControls: {
+  flexDirection: "row",
+  alignItems: "center",
+  justifyContent: "center",
+  width: "100%",
+  paddingHorizontal: theme.spacing.md_12,
+},
+progressContainer: {
+  flex: 1,
+},
   progressBar: {
     position: "relative",
     justifyContent: "center",
   },
-  timeRow: {
-    flexDirection: "row",
-    justifyContent: "space-between",
-    alignItems: "center",
-    marginBottom: theme.spacing.xs,
-  },
+timeRow: {
+  flexDirection: "row",
+  alignItems: "center",
+  justifyContent: "space-between",
+},
+centerPlaybackControls: {
+  flexDirection: "row",
+  alignItems: "center",
+  justifyContent: "center",
+  height: 50,
+},
+skipButton: {
+  width: 45,
+  height: 45,
+  justifyContent: "center",
+  alignItems: "center",
+},
+playButton: {
+  justifyContent: "center",
+  alignItems: "center",
+  marginHorizontal: 12,
+},
+playButtonLoadingSpinner: {
+  width: 30,
+  height: 30,
+},
   timestamp: {
     fontSize: theme.typography.sizes.md,
     fontFamily: theme.typography.fonts.balooPaaji,
@@ -199,7 +210,6 @@ export const audioControlBarStyles = (theme) => ({
     justifyContent: "center",
   },
 });
-
 export const audioTrackDialogStyles = (theme) => ({
   modalWrapper: {
     position: "relative",
@@ -325,6 +335,16 @@ export const audioTrackDialogStyles = (theme) => ({
     fontFamily: theme.typography.fonts.balooPaaji,
     fontVariant: ["tabular-nums"],
   },
+centerPlaybackControls: {
+  flexDirection: "row",
+  alignItems: "center",
+  justifyContent: "center",
+},
+skipButton: {
+  justifyContent: "center",
+  alignItems: "center",
+  marginHorizontal: 8,
+},
   nextLoadingSpinner: {
     marginRight: theme.spacing.sm,
   },

--- a/src/common/icons/Forward10Icon.jsx
+++ b/src/common/icons/Forward10Icon.jsx
@@ -1,0 +1,57 @@
+import React from "react";
+import Svg, { Path, Polyline, Rect } from "react-native-svg";
+import PropTypes from "prop-types";
+
+const Forward10Icon = ({ size = 24, color }) => {
+    return (
+        <Svg
+            width={size}
+            height={size}
+            viewBox="0 0 64 64"
+            fill="none"
+        >
+            {/* Number 1 (smaller) */}
+            <Path
+                d="M25.5 38.8V25.5a.09.09 0 0 0-.16-.07s-1.9 2.7-3.3 3.8"
+                stroke={color}
+                strokeWidth="4"
+                strokeLinecap="round"
+            />
+
+            {/* Number 0 (smaller) */}
+            <Rect
+                x="31"
+                y="24.5"
+                width="9"
+                height="15"
+                rx="4.5"
+                stroke={color}
+                strokeWidth="4"
+            />
+
+            {/* Arrow head */}
+            <Polyline
+                points="54.43 15.41 51.83 24.05 43.19 21.44"
+                stroke={color}
+                strokeWidth="4"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+            />
+
+            {/* Circular arrow */}
+            <Path
+                d="M51.86 23.94a21.91 21.91 0 1 0 .91 13.25"
+                stroke={color}
+                strokeWidth="4"
+                strokeLinecap="round"
+            />
+        </Svg>
+    );
+};
+
+Forward10Icon.propTypes = {
+    size: PropTypes.number,
+    color: PropTypes.string.isRequired,
+};
+
+export default Forward10Icon;

--- a/src/common/icons/Replay10Icon.jsx
+++ b/src/common/icons/Replay10Icon.jsx
@@ -1,0 +1,57 @@
+import React from "react";
+import Svg, { Path, Polyline, Rect } from "react-native-svg";
+import PropTypes from "prop-types";
+
+const Replay10Icon = ({ size = 24, color }) => {
+    return (
+        <Svg
+            width={size}
+            height={size}
+            viewBox="0 0 64 64"
+            fill="none"
+        >
+            {/* Arrow head */}
+            <Polyline
+                points="9.57 15.41 12.17 24.05 20.81 21.44"
+                stroke={color}
+                strokeWidth="4"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+            />
+
+            {/* Number 1 (smaller) */}
+            <Path
+                d="M25.5 38.8V25.5a.09.09 0 0 0-.16-.07s-1.9 2.7-3.3 3.8"
+                stroke={color}
+                strokeWidth="4"
+                strokeLinecap="round"
+            />
+
+            {/* Number 0 (smaller) */}
+            <Rect
+                x="31"
+                y="24.5"
+                width="9"
+                height="15"
+                rx="4.5"
+                stroke={color}
+                strokeWidth="4"
+            />
+
+            {/* Circular rewind arrow */}
+            <Path
+                d="M12.14 23.94a21.91 21.91 0 1 1-.91 13.25"
+                stroke={color}
+                strokeWidth="4"
+                strokeLinecap="round"
+            />
+        </Svg>
+    );
+};
+
+Replay10Icon.propTypes = {
+    size: PropTypes.number,
+    color: PropTypes.string.isRequired,
+};
+
+export default Replay10Icon;

--- a/src/common/icons/index.js
+++ b/src/common/icons/index.js
@@ -3,6 +3,8 @@ export { default as SettingsIcon } from "./SettingsIcon";
 export { default as ExpandCollapseIcon } from "./ExpandCollapseIcon";
 export { default as CloseIcon } from "./CloseIcon";
 export { default as PlayIcon } from "./PlayIcon";
+export { default as Replay10Icon } from "./Replay10Icon";
+export { default as Forward10Icon } from "./Forward10Icon";
 export { default as DownloadIcon } from "./DownloadIcon";
 export { default as ArrowRightIcon } from "./ArrowRightIcon";
 export { default as CircleIcon } from "./CircleIcon";


### PR DESCRIPTION


#385  

### Changes
* Added 10-second rewind and forward buttons with new SVG icons.
* Updated playback control layout and styling for better alignment.
* Kept existing play/pause, buffering, loading, and seeking logic unchanged.

### Testing
* Verified audio player controls on iOS Simulator and device.
* Confirmed play/pause, rewind, forward, and progress slider functionality.

<img width="300" alt="Simulator Screenshot - iPhone 16 Pro - 2026-07-26 at 13 28 05" src="https://github.com/user-attachments/assets/58f26492-02b7-42bf-af1c-6d4946c33b1f" />
